### PR TITLE
Improve android licenses

### DIFF
--- a/docker-android-build/Dockerfile
+++ b/docker-android-build/Dockerfile
@@ -28,18 +28,18 @@ RUN rm android-sdk.zip
 
 RUN sdkmanager "emulator" "tools" "platform-tools"
 RUN yes | sdkmanager \
-	"build-tools;25.0.2" \
-	"build-tools;24.0.3"
+	"build-tools;24.0.3" \
+	"build-tools;25.0.2"
 RUN yes | sdkmanager \
     "extras;android;m2repository" \
     "extras;google;m2repository" \
     "extras;google;google_play_services" 
 
 RUN yes | sdkmanager \
-    "platforms;android-25" \
-    "platforms;android-22" \
+    "platforms;android-15" \
     "platforms;android-21" \
-    "platforms;android-15"
+    "platforms;android-22" \
+    "platforms;android-25"
 
 ##################
 # Android licenses

--- a/docker-android-build/Dockerfile
+++ b/docker-android-build/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Veaceslav Gaidarji <veaceslav.gaidarji@gmail.com>"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
     ANDROID_HOME=/opt/android-sdk \
-    PATH="$PATH:/usr/lib/jvm/java-8-oracle/bin:/opt/android-sdk/tools:/opt/android-sdk/platform-tools"
+    PATH="$PATH:/usr/lib/jvm/java-8-openjdk-amd64/bin:/opt/android-sdk/tools:/opt/android-sdk/tools/bin:/opt/android-sdk/platform-tools"
 
 RUN apt-get update -qq
 RUN apt-get install -y --no-install-recommends wget lib32stdc++6 libqt5widgets5 lib32z1 unzip
@@ -18,32 +18,33 @@ RUN apt-get install -y openjdk-8-jdk && \
     apt-get clean
 RUN java -version
 
-##################
-# Android licenses
-##################
-RUN mkdir /opt/android-sdk/
-RUN mkdir /opt/android-sdk/licenses/
-RUN echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /opt/android-sdk/licenses/android-sdk-license
-RUN echo "\nd56f5187479451eabf01fb78af6dfcb131a6481e" > /opt/android-sdk/licenses/android-sdk-license
-RUN echo "84831b9409646a918e30573bab4c9c91346d8abd" > /opt/android-sdk/licenses/android-sdk-preview-license
-RUN echo "d975f751698a77b662f1254ddbeed3901e976f5a" > /opt/android-sdk/licenses/intel-android-extra-license
-
 ###################
 # Android SDK
 ###################
-RUN wget -O android-sdk.zip https://dl.google.com/android/repository/tools_r25.2.3-linux.zip
-RUN unzip -a android-sdk.zip
+RUN mkdir /opt/android-sdk/
+RUN wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
+RUN unzip -q android-sdk.zip -d ${ANDROID_HOME}
 RUN rm android-sdk.zip
-RUN mv /tools /opt/android-sdk/tools
-RUN echo $ANDROID_HOME
-RUN echo $PATH
-RUN ls -al /opt
-RUN ls -al /opt/android-sdk
-RUN ls -al /opt/android-sdk/tools
-RUN echo 'y' | android update sdk --no-ui --all --filter "platform-tools,build-tools-25.0.2,build-tools-24.0.3"
-RUN echo 'y' | android update sdk --no-ui --all --filter "extra-google-support,extra-android-support,extra-google-m2repository,extra-android-m2repository,extra-google-google_play_services"
-RUN echo 'y' | android update sdk --no-ui --all --filter "android-15,android-21,android-22,android-25"
-RUN rm -rf /opt/android-sdk/add-ons
+
+RUN sdkmanager "emulator" "tools" "platform-tools"
+RUN yes | sdkmanager \
+	"build-tools;25.0.2" \
+	"build-tools;24.0.3"
+RUN yes | sdkmanager \
+    "extras;android;m2repository" \
+    "extras;google;m2repository" \
+    "extras;google;google_play_services" 
+
+RUN yes | sdkmanager \
+    "platforms;android-25" \
+    "platforms;android-22" \
+    "platforms;android-21" \
+    "platforms;android-15"
+
+##################
+# Android licenses
+##################
+RUN yes | sdkmanager --licenses
 
 ##################
 # Speeding up android builds

--- a/docker-android-emulator/Dockerfile
+++ b/docker-android-emulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM vgaidarji/docker-android-build:improve-android-licenses
+FROM vgaidarji/docker-android-build:v1.0.1
 
 ##################
 # Install emulator images

--- a/docker-android-emulator/Dockerfile
+++ b/docker-android-emulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM vgaidarji/docker-android-build:1.0.0
+FROM vgaidarji/docker-android-build:improve-android-licenses
 
 ##################
 # Install emulator images

--- a/docker-android-emulator/Dockerfile
+++ b/docker-android-emulator/Dockerfile
@@ -3,7 +3,7 @@ FROM vgaidarji/docker-android-build:1.0.0
 ##################
 # Install emulator images
 ##################
-RUN echo 'y' | android update sdk -a -u -t "sys-img-armeabi-v7a-android-21"
+RUN sdkmanager "system-images;android-21;google_apis;armeabi-v7a"
 
 ##################
 # Set mandatory environment variables


### PR DESCRIPTION
### What has been done
- Migrated to SDK tools 26.1.1 version
- Android licenses are no longer manually accepted but via `sdkmanager`
- Used `sdkmanager` to install dependencies