### PR TITLE
Fix issue with Android Emulator not started

### DIFF
--- a/docker-android-emulator/ui-tests-on-emulator.sh
+++ b/docker-android-emulator/ui-tests-on-emulator.sh
@@ -5,9 +5,22 @@ set -eu
 # start android emulator
 START=`date +%s` > /dev/null
 
-echo no | $ANDROID_HOME/tools/android create avd --force -n test -t android-21 --abi default/armeabi-v7a
+# AVD name that will be used to start the image
+AVD_NAME="android-29"
+
+# AVD image identifier, use "sdkmanager --list" to check all available
+ANDROID_IMAGE="system-images;$AVD_NAME;google_apis;x86_64"
+
+# install avd image, in case it's missing
+echo no | $ANDROID_HOME/tools/bin/sdkmanager --install "$ANDROID_IMAGE"
+
+# create AVD
+echo no | $ANDROID_HOME/tools/android create avd -f -n "$AVD_NAME" -k "$ANDROID_IMAGE"
 $ANDROID_HOME/tools/android list avd
-$ANDROID_HOME/tools/emulator64-arm -avd test -no-window -no-boot-anim -no-audio -verbose &
+
+# start emulator
+$ANDROID_HOME/tools/emulator -avd $AVD_NAME -no-window -no-boot-anim -no-audio -verbose &
+
 wait-for-emulator
 unlock-emulator-screen
 


### PR DESCRIPTION
- It seems that the flag '-t' is not being used anymore, not sure since when as I couldn't find any documentation

- To ensure that the API is installed we run the sdkmanager --install 
- API Level used now is "android-29" - changed as running "android-21" as previously the emulator warns that the 21 emulator is significantly slower
- Use the -k flag as recommended from the [avdmanager doc](https://developer.android.com/studio/command-line/avdmanager)
- To find list of AVD's you can run 'sdkmanager --list'

The installation of the SDK should happen only once.

Closes Issue: 
https://github.com/vgaidarji/docker-android/issues/11

(disclaimer: this is my first github action modification or any addition)